### PR TITLE
Update to OWL API v5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<sesame.version>2.7.12</sesame.version>
 		<logback.version>1.1.3</logback.version>
 		<slf4j.version>1.7.12</slf4j.version>
-		<owlapi.version>4.5.15</owlapi.version>
+		<owlapi.version>5.1.13</owlapi.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/protege/owl/rdf/Utilities.java
+++ b/src/main/java/org/protege/owl/rdf/Utilities.java
@@ -8,6 +8,7 @@ import org.openrdf.sail.memory.MemoryStore;
 import org.protege.owl.rdf.api.OwlTripleStore;
 import org.protege.owl.rdf.impl.OwlTripleStoreImpl;
 import org.protege.owl.rdf.impl.SynchronizeTripleStoreListener;
+import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -19,15 +20,15 @@ public class Utilities {
 		
 	}
 	
-	public static OwlTripleStore getOwlTripleStore(OWLDataFactory factory) throws RepositoryException {
+	public static OwlTripleStore getOwlTripleStore(OWLOntologyManager manager) throws RepositoryException {
 		Sail sailStack = new MemoryStore();
 		Repository repository = new SailRepository(sailStack);
 		repository.initialize();
-		return new OwlTripleStoreImpl(repository, factory);
+		return new OwlTripleStoreImpl(repository, manager);
 	}
 	
 	public static OwlTripleStore getOwlTripleStore(OWLOntologyManager manager, boolean sync) throws RepositoryException {
-		OwlTripleStore ots = getOwlTripleStore(manager.getOWLDataFactory());
+		OwlTripleStore ots = getOwlTripleStore(manager);
 		for (OWLOntology ontology : manager.getOntologies()) {
 			loadOwlTripleStore(ots, ontology, false);
 		}
@@ -38,7 +39,7 @@ public class Utilities {
 	}
 	
 	public static OwlTripleStore getOwlTripleStore(OWLOntology ontology, boolean sync) throws RepositoryException {
-		OwlTripleStore ots = getOwlTripleStore(ontology.getOWLOntologyManager().getOWLDataFactory());
+		OwlTripleStore ots = getOwlTripleStore(ontology.getOWLOntologyManager());
 		loadOwlTripleStore(ots, ontology, sync);
 		return ots;
 	}

--- a/src/main/java/org/protege/owl/rdf/impl/OwlTripleStoreImpl.java
+++ b/src/main/java/org/protege/owl/rdf/impl/OwlTripleStoreImpl.java
@@ -74,14 +74,14 @@ public class OwlTripleStoreImpl implements OwlTripleStore {
     };
 	
 	
-	public OwlTripleStoreImpl(Repository repository, OWLDataFactory factory) {
+	public OwlTripleStoreImpl(Repository repository, OWLOntologyManager manager) {
 		this.repository = repository;
 		ValueFactory rdfFactory = repository.getValueFactory();
 		hashCodeProperty        = rdfFactory.createURI(HASH_CODE);
 		sourceOntologyProperty  = rdfFactory.createURI(SOURCE_ONTOLOGY);
 		ontologyIdProperty      = rdfFactory.createURI(ONTOLOGY_ID);
 		ontologyVersionProperty = rdfFactory.createURI(ONTOLOGY_VERSION);
-		anonymousHandler = new AnonymousResourceHandler(factory);
+		anonymousHandler = new AnonymousResourceHandler(manager);
 	}
 
 	@Override

--- a/src/main/java/org/protege/owl/rdf/impl/RDFTranslator.java
+++ b/src/main/java/org/protege/owl/rdf/impl/RDFTranslator.java
@@ -10,14 +10,12 @@ import org.openrdf.repository.RepositoryException;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.rdf.model.AbstractTranslator;
-import org.semanticweb.owlapi.util.AlwaysOutputId;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class RDFTranslator extends AbstractTranslator<Value, Resource, org.openrdf.model.URI, org.openrdf.model.Literal> {
@@ -83,20 +81,6 @@ public class RDFTranslator extends AbstractTranslator<Value, Resource, org.openr
 		}
 	}
 
-	/**
-	 * Gets a fresh anonymous resource.
-	 *
-	 * @param key     A key for the resource. Each call will create a new node; nodes cannot clash.
-	 * @param isAxiom true if axiom
-	 * @return The resource
-	 */
-	@Nonnull
-	@Override
-	protected Resource getAnonymousNodeForExpressions(@Nonnull Object key,
-													  boolean isAxiom) {
-		return rdfFactory.createBNode();
-	}
-
 	private static OWLOntology createOntology(OWLOntologyManager manager, OWLAxiom axiom) throws OWLOntologyCreationException {
 		Set<OWLAxiom> axiomSet = new HashSet<>();
 		axiomSet.add(axiom);
@@ -104,7 +88,7 @@ public class RDFTranslator extends AbstractTranslator<Value, Resource, org.openr
 	}
 
 	private RDFTranslator(Repository repository, OWLOntologyManager manager, OWLOntology ontology) throws RepositoryException {
-		super(manager, ontology, null,false, new AlwaysOutputId(), new AlwaysOutputId(), new AtomicInteger(1), new HashMap<>(), new HashSet<>());
+		super(manager, ontology, null,false, i -> true, new HashSet<>());
 		rdfFactory = repository.getValueFactory();
 		axiomResource = rdfFactory.createURI(OwlTripleStoreImpl.NS + "/" + UUID.randomUUID().toString().replace('-', '_'));
 		connection = repository.getConnection();

--- a/src/test/java/org/protege/owl/rdf/AnonymityTests.java
+++ b/src/test/java/org/protege/owl/rdf/AnonymityTests.java
@@ -56,7 +56,7 @@ public class AnonymityTests {
         Sail sailStack = new MemoryStore();
         Repository repository = new SailRepository(sailStack);
         repository.initialize();
-        ots = new OwlTripleStoreImpl(repository, OWLManager.getOWLDataFactory());
+        ots = new OwlTripleStoreImpl(repository, OWLManager.createOWLOntologyManager());
     }
     
     @Test

--- a/src/test/java/org/protege/owl/rdf/ImportTests.java
+++ b/src/test/java/org/protege/owl/rdf/ImportTests.java
@@ -38,7 +38,7 @@ public class ImportTests {
         Sail sailStack = new MemoryStore();
         Repository repository = new SailRepository(sailStack);
         repository.initialize();
-        ots = new OwlTripleStoreImpl(repository, OWLManager.getOWLDataFactory());
+        ots = new OwlTripleStoreImpl(repository, OWLManager.createOWLOntologyManager());
     }
     
 	@Test


### PR DESCRIPTION
 I have a performance  problem with `RDFTranslator.createOntology`. So I thought as I first step I would try and update to the latest OWL API. This continues from where #8 stops.

I have managed to get the code to compile against the newer API :-) ...but I am a bit stuck in `AnonymousResourceHandler`. I have to admit that I am out of my depth in there as I don't really understand what it should do.

Whilst the code compiles, the following tests fail (all related to `AnonymousResourceHandler` I think):

```
Results :

Failed tests:
  AnonymityTests.annotationAssertionWithAnonymousSubject:155 » OWLRuntime Not an...
  AnonymityTests.axiomWithAnonymousAnnotationValue:133 » OWLRuntime Not an anony...
  AnonymityTests.axiomWithAnonymousIndividualTest1:70 » OWLRuntime Not an anonym...
  AnonymityTests.axiomWithAnonymousIndividualTest2:95 » OWLRuntime Not an anonym...
  AnonymityTests.axiomWithAnonymousIndividualTest3:108 » OWLRuntime Not an anony...
  PizzaTests.testHasAxiom:52 expected [true] but found [false]
  PizzaTests.testListAxioms:64 expected [true] but found [false]
```

Perhaps someone who knows this code and API better than me could collaborate on this PR to finish the last bits to make this work :-)